### PR TITLE
(feedback) Namespaced Grappa node functions

### DIFF
--- a/system/Communicator.hpp
+++ b/system/Communicator.hpp
@@ -46,7 +46,9 @@
 typedef void (*HandlerPointer)();    
 
 /// Type for Node ID. 
-typedef int16_t Node;
+typedef int16_t Core;
+/// @legacy
+typedef Core Node;
 
 /// Maximum size of GASNet medium active message payload. 
 ///

--- a/system/Grappa.hpp
+++ b/system/Grappa.hpp
@@ -221,8 +221,8 @@ static inline void Grappa_idle_flush_poll() {
 void Grappa_take_profiling_sample();
 
 namespace Grappa {
-  inline Node nodes() { return Grappa_nodes(); }
-  inline Node mynode() { return Grappa_mynode(); }
+  inline Core cores() { return Grappa_nodes(); }
+  inline Core mycore() { return Grappa_mynode(); }
 }
 
 #include "Addressing.hpp"


### PR DESCRIPTION
Jacob has already started refactoring many functions into `namespace Grappa` (and `Grappa::impl`) and getting rid of the `Grappa_` prefix.

This branch is intended to be used to do this refactoring.

_First_, however, I wanted to discuss whether we should tie down the "Node" vs. "Core" terminology. Should we do away completely with `Node`, and call these functions `Grappa::mycore()`? Or something else?
