### PR TITLE
Add stats to distinguish async delegates and short-circuiting

### DIFF
--- a/system/AsyncDelegate.cpp
+++ b/system/AsyncDelegate.cpp
@@ -1,0 +1,5 @@
+#include "AsyncDelegate.hpp"
+
+GRAPPA_DEFINE_STAT(SimpleStatistic<int64_t>, delegate_async_ops, 0);
+GRAPPA_DEFINE_STAT(SimpleStatistic<int64_t>, delegate_async_writes, 0);
+GRAPPA_DEFINE_STAT(SimpleStatistic<int64_t>, delegate_async_increments, 0);

--- a/system/Delegate.cpp
+++ b/system/Delegate.cpp
@@ -17,6 +17,7 @@
 #include <glog/logging.h>
 
 GRAPPA_DEFINE_STAT(SummarizingStatistic<uint64_t>, flat_combiner_fetch_and_add_amount, 0);
+GRAPPA_DEFINE_STAT(SimpleStatistic<uint64_t>, delegate_ops_short_circuited, 0);
 
 /// Descriptor for delegate operation.
 /// Used to hold state while waiting for reply.

--- a/system/Delegate.hpp
+++ b/system/Delegate.hpp
@@ -18,7 +18,8 @@
 #include "MessagePool.hpp"
 #include <type_traits>
 
-GRAPPA_DECLARE_STAT( SummarizingStatistic<uint64_t>, flat_combiner_fetch_and_add_amount );
+GRAPPA_DECLARE_STAT(SummarizingStatistic<uint64_t>, flat_combiner_fetch_and_add_amount);
+GRAPPA_DECLARE_STAT(SimpleStatistic<uint64_t>, delegate_ops_short_circuited);
 
 namespace Grappa {
   namespace delegate {
@@ -33,6 +34,7 @@ namespace Grappa {
       
       if (dest == origin) {
         // short-circuit if local
+        delegate_ops_short_circuited++;
         return func();
       } else {
         int64_t network_time = 0;

--- a/system/Makefile
+++ b/system/Makefile
@@ -308,7 +308,8 @@ LIBRARY_CONTENTS+= Grappa.o \
 				   RDMAAggregator.o \
 				   ParallelLoop.o \
 				   Barrier.o \
-				   MessagePool.o
+				   MessagePool.o \
+					 AsyncDelegate.o
 
 libGrappa.a: $(LIBRARY_CONTENTS)
 	$($(MPITYPE)_AR) rv $@ $^

--- a/system/New_delegate_tests.cpp
+++ b/system/New_delegate_tests.cpp
@@ -124,7 +124,7 @@ void check_async_delegates() {
   BOOST_MESSAGE("  feed forward...");
   const int N = 1 << 8;
   
-  MessagePool pool(N*(1<<8));
+  MessagePool pool(3*N*(1<<8));
 
   delegate::write(make_global(&global_x,1), 0);
   
@@ -134,6 +134,17 @@ void check_async_delegates() {
   mygce.wait();
   
   BOOST_CHECK_EQUAL(delegate::read(make_global(&global_x,1)), N);
+  
+  auto xa = make_global(&global_x,1);
+  delegate::write_async<&mygce>(pool, xa, 0);
+  mygce.wait();
+  
+  for (int i=0; i<N; i++) {
+    delegate::increment_async<&mygce>(pool, xa, 1);
+  }
+  mygce.wait();
+  
+  BOOST_CHECK_EQUAL(delegate::read(xa), N);
   
   delegate::call(1, []{
     global_y = 0;


### PR DESCRIPTION
@bmyerz, @nelsonje: Let me know what you think, if you think we're going to need anything else.

My thought is that we just need to be able to have a count of the number of ops (of each kind) that were asynchronous, but when we do our typical measures of the number of delegate ops, we want those counts to represent the total (including asyncs), so that's what I did. If you guys disagree, let me know.
