### PR TITLE
Fix SharedMessagePool + all the new graph stuff

### DIFF
--- a/system/Grappa.cpp
+++ b/system/Grappa.cpp
@@ -391,7 +391,7 @@ void Grappa_activate()
     double gheap_sz_gb = static_cast<double>(global_bytes_per_core) / (1L<<30);
     size_t shpool_sz = FLAGS_shared_pool_max * FLAGS_shared_pool_size;
     double shpool_sz_gb = static_cast<double>(shpool_sz) / (1L<<30);
-    size_t free_sz = Grappa::impl::locale_shared_memory.get_free_memory() / locale_cores();
+    size_t free_sz = Grappa::impl::locale_shared_memory.get_free_memory() / Grappa::locale_cores();
     double free_sz_gb = free_sz / (1L<<30);
     VLOG(1) << "\n-------------------------\nShared memory breakdown:\n  global heap: " << global_bytes_per_core << " (" << gheap_sz_gb << " GB)\n  stacks: " << stack_sz << " (" << stack_sz_gb << " GB)\n  rdma_aggregator: ??\n  shared_message_pool: " << shpool_sz << " (" << shpool_sz_gb << " GB)\n  free:  " << free_sz << " (" << free_sz_gb << " GB)\n-------------------------";
   }


### PR DESCRIPTION
Okay, I think I fixed the SharedMessagePool issues. Long story, but I think the main issue was how I was calling a long chain of methods, including a virtual call, on the constantly-changing `shared_pool` global, which caused some things to not work as expected. Once I removed some of the indirection and allocated directly from shared_pool in `heap_message`, all worked as expected (with my new implementation).

I'm not seeing the issues Jacob was having in the demo GUPS, and it seems to be working alright for my new BFS/CC implementations. I've set a max that restricts the shared pool to use 1GB. This seems to be sufficient on the grappa cluster with our current defaults, we don't even hit that cap at steady state.

@nelsonje, @bmyerz, @agent-lee: If you guys wouldn't mind testing it in a couple places where you use it, I would appreciate it.
