### PR TITLE
Remove SHMMAX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ include(ExternalProject)
 option(TRACING "Sample statistics with VTrace at regular intervals." OFF)
 option(PROFILING "Sample profile with GPerftools at regular intervals." OFF)
 
-set(SHMMAX "" CACHE STRING "Size of SysV shared memory")
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
 # if( NOT DEFINED ENV{CXX} )
@@ -182,10 +180,6 @@ list(APPEND GRAPPA_ENV
   GLOG_v=1
 )
 
-
-add_definitions(-DSHMMAX=${SHMMAX})
-# add_definitions(-DSHMMAX=12884901888) # 12 GB
-# add_definitions(-DSHMMAX=6442450944) # 6 GB
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # clang doesn't have this flag it seems, needed for Relation_io_tests.cpp in Travis

--- a/configure
+++ b/configure
@@ -30,7 +30,6 @@ OptionParser.new{|p|
   p.on('--profiling',"Enable gperftools-based sampled profiling."){|b| opt.profiling = true }
   p.on('--vampir=path/to/vampirtrace/root',"Specify path to VampirTrace build (enables tracing)."){|p| opt.vampir = p; opt.tracing = true }
   p.on('--third-party=path/to/built/deps/root',"Can optionally pre-build third-party dependencies #{line_break}instead of re-building for each configuration."){|p| opt.third_party = p }
-  p.on('--shmmax=SIZE',"Manually set maximum SysV shared memory size"){|n| opt.shmmax = n }
   p.on('--build-here', "Just configure into current directory rather than creating new build directories."){|b| opt.build_here = true }
   p.on('--no-downloads', "Expect third-party dependences to already exist in third-party/downloads, rather than downloading them from the web."){|b| opt.no_downloads = true }
 }.parse!(ARGV)
@@ -84,19 +83,6 @@ def configure(generator, mode, opt)
     args << %Q[-G"#{generator}"]
   end
   
-  # determine shared memory size
-  unless opt.shmmax
-    opt.shmmax = `sysctl kernel.shmmax 2>/dev/null`
-    if not $?.success?
-      opt.shmmax = `sysctl kern.sysv.shmmax 2>/dev/null`
-      if not $?.success?
-        abort "error: unable to determine max SysV shared memory size automatically. Please set it manually with --shmmax option (usually half your main memory size)."
-      end
-    end
-  end
-  args << "-DSHMMAX=#{opt.shmmax[/(\d+)$/]}" if opt.shmmax
-  
-
   if opt.no_downloads
     args << "-DNO_DOWNLOADS=true"
   end

--- a/system/Grappa.cpp
+++ b/system/Grappa.cpp
@@ -51,10 +51,6 @@
 
 #include "Grappa.hpp"
 
-#ifndef SHMMAX
-#error "no SHMMAX defined for this system -- look it up with the command: `sysctl -A | grep shm`"
-#endif
-
 #ifdef VTRACE
 #include <vt_user.h>
 #endif
@@ -62,6 +58,8 @@
 // command line arguments
 DEFINE_uint64( num_starting_workers, 512, "Number of starting workers in task-executer pool" );
 DEFINE_bool( set_affinity, false, "Set processor affinity based on local rank" );
+
+DEFINE_int64( node_memsize, -1, "User-specified node memory size; overrides autodetection" );
 
 DEFINE_uint64( io_blocks_per_node, 4, "Maximum number of asynchronous IO operations to issue concurrently per node.");
 DEFINE_uint64( io_blocksize_mb, 4, "Size of each asynchronous IO operation's buffer." );
@@ -102,7 +100,7 @@ namespace Grappa {
   IODescriptor * aio_completed_stack;
   
   namespace impl {
-    
+
     int64_t global_memory_size_bytes = 0;
     int64_t global_bytes_per_core = 0;
     int64_t global_bytes_per_locale = 0;
@@ -147,14 +145,14 @@ namespace Grappa {
         new_bpp = 1L << 30;
       }
       MASTER_ONLY VLOG_IF(1, bytes_per_core != new_bpp) << "With ppn=" << ppn << ", can only allocate "
-      << pages_per_core*ppn << " / " << SHMMAX / (1L << 30) << " 1GB huge pages per node";
+      << pages_per_core*ppn << " / " << FLAGS_node_memsize / (1L << 30) << " 1GB huge pages per node";
       bytes_per_core = new_bpp;
     }
     
     int64_t bytes = nnode * ppn * bytes_per_core;
     int64_t bytes_per_node = ppn * bytes_per_core;
     MASTER_ONLY DVLOG(2) << "bpp = " << bytes_per_core << ", bytes = " << bytes << ", bytes_per_node = " << bytes_per_node
-    << ", SHMMAX = " << SHMMAX << ", heap_size = " << sz;
+    << ", node_memsize = " << FLAGS_node_memsize << ", heap_size = " << sz;
     MASTER_ONLY VLOG(2) << "nnode: " << nnode << ", ppn: " << ppn << ", iBs/node: " << log2((double)bytes_per_node) << ", total_iBs: " << log2((double)bytes);
     
     impl::global_memory_size_bytes = bytes;
@@ -279,7 +277,7 @@ void adjust_footprints() {
   auto locale_cores = global_communicator.locale_cores;
   auto locale_total = FLAGS_locale_shared_size;
   
-  // (FLAGS_locale_shared_size either set manually or computed from fraction of SHMMAX)
+  // (FLAGS_locale_shared_size either set manually or computed from fraction of node_memsize)
   auto locale_heap_bytes = static_cast<size_t>(FLAGS_locale_user_heap_fraction * (double)locale_total);
   auto global_heap_bytes = Grappa::impl::global_memory_size_bytes;
   
@@ -289,7 +287,7 @@ void adjust_footprints() {
     << "\nMust leave some memory for Grappa system components!\n"
     << " - locale_heap_bytes: " << locale_heap_bytes << "\n"
     << " - global_heap_bytes: " << global_heap_bytes << "\n"
-    << " - total (SHMMAX):    " << locale_total;
+    << " - total:    " << locale_total;
   
   auto total_footprint = []{
     return global_communicator.estimate_footprint()
@@ -482,6 +480,13 @@ void Grappa_init( int * argc_p, char ** argv_p[], int64_t global_memory_size_byt
 #endif
 
   // initialize node shared memory
+  if( FLAGS_node_memsize == -1 ) { 
+    // if user doesn't specify how much memory each node has, try to estimate.
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    FLAGS_node_memsize = pages * page_size;
+    VLOG(2) << "Estimated node memory size = " << FLAGS_node_memsize;
+  }
   locale_shared_memory.init();
   
   // initialize shared message pool
@@ -565,6 +570,7 @@ void Grappa_activate()
   auto shared_pool_locale_shared_memory_allocated = locale_shared_memory.get_allocated();
   
   if (Grappa::mycore() == 0) {
+    double node_sz_gb = static_cast<double>(FLAGS_node_memsize) / (1L<<30);
     double locale_sz_gb = static_cast<double>(FLAGS_locale_shared_size) / (1L<<30);
     double locale_core_sz_gb = static_cast<double>(FLAGS_locale_shared_size) / Grappa::locale_cores() / (1L<<30);
     double communicator_sz_gb = static_cast<double>( communicator_locale_shared_memory_allocated - base_locale_shared_memory_allocated ) / (1L<<30);
@@ -579,6 +585,7 @@ void Grappa_activate()
     double free_sz_gb = static_cast<double>(free_sz) / (1L<<30);
     double free_core_sz_gb = static_cast<double>(free_sz) / Grappa::locale_cores() / (1L<<30);
     VLOG(1) << "\n-------------------------\nShared memory breakdown:\n"
+            << "  node total:                   " << node_sz_gb << " GB\n"
             << "  locale shared heap total:     " << locale_sz_gb << " GB\n"
             << "  locale shared heap per core:  " << locale_core_sz_gb << " GB\n"
             << "  communicator per core:        " << communicator_sz_gb << " GB\n"

--- a/system/LocaleSharedMemory.cpp
+++ b/system/LocaleSharedMemory.cpp
@@ -23,18 +23,15 @@
 
 #include "LocaleSharedMemory.hpp"
 
-#ifndef SHMMAX
-#error "no SHMMAX defined for this system -- look it up with the command: `sysctl -A | grep shm`"
-#endif
+DEFINE_int64( locale_shared_size, 0, "Total shared memory between cores on node (when 0, defaults to locale_shared_fraction * total node memory)" );
 
-DEFINE_int64( locale_shared_size, 0, "Total shared memory between cores on node (when 0, defaults to locale_shared_fraction * SHMMAX)" );
-
-DEFINE_double( locale_shared_fraction, 1.0, "Fraction of SHMMAX to allocate for Grappa" );
+DEFINE_double( locale_shared_fraction, 0.5, "Fraction of total node memory to allocate for Grappa" );
 
 DEFINE_double( locale_user_heap_fraction, 0.1, "Fraction of locale shared memory to set aside for the user" );
 
 DEFINE_double( global_heap_fraction, 0.25, "Fraction of locale shared memory to set aside for global shared heap" );
 
+DECLARE_int64( node_memsize );
 DECLARE_bool( global_memory_use_hugepages );
 
 // forward declarations
@@ -146,7 +143,7 @@ LocaleSharedMemory::LocaleSharedMemory()
   boost::interprocess::shared_memory_object::remove( region_name.c_str() );
 
   // TODO: figure out reasonable region size
-  // maybe reuse SHMMAX stuff?
+  // maybe reuse total memory measurement?
   
 }
 
@@ -156,7 +153,7 @@ LocaleSharedMemory::~LocaleSharedMemory() {
 
 void LocaleSharedMemory::init() {
   if( 0 == FLAGS_locale_shared_size ) {
-    double locale_shared_size = FLAGS_locale_shared_fraction * static_cast< double >( SHMMAX );
+    double locale_shared_size = FLAGS_locale_shared_fraction * static_cast< double >( FLAGS_node_memsize );
     region_size = static_cast< int64_t >( locale_shared_size );
     FLAGS_locale_shared_size = region_size;
   }


### PR DESCRIPTION
@bholt, @bmyerz:

I've torn out all SHMMAX stuff and replaced it with some code to estimate total node memory size (which can be overridden with the ```--node_memsize``` flag). I'm still setting the locale shared heap to half of total node memory: it's certainly possible to run with this set much larger (for instance, 0.9*total node memory works for GUPS), but I figure we should get some experience running large jobs with it before changing the default.