### PR TITLE
Fix Travis CI builds to use installed Boost again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,23 @@ compiler:
 #   - sudo apt-get update -qq
 #   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.7; fi
 #   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
-before_script:
+before_install:
+  ### add PPA for modern version of boost
   - sudo add-apt-repository ppa:boost-latest/ppa -y
   - sudo apt-get update -q
-  - sudo apt-get install libboost1.54-all-dev
-  - export MPIEXEC='mpiexec -launcher fork'
-before_install:
-  - "sudo apt-get remove openmpi-bin openmpi-common openmpi-doc -y && echo '@> '`which mpiexec`"
-  
-  - sudo apt-get install -q gfortran libcr0 default-jdk
+  ### install boost and other necessary packages
+  - sudo apt-get install -q gfortran libcr0 default-jdk libboost1.54-all-dev
+  ### get an MPI that supports MPI-3 
   - wget -q http://www.cebacad.net/files/mpich/ubuntu/mpich-3.1/mpich_3.1-1ubuntu_amd64.deb;
   - sudo dpkg -i ./mpich_3.1-1ubuntu_amd64.deb
   - rm -f ./mpich_3.1-1ubuntu_amd64.deb
-  # - wget http://www.cebacad.net/files/mpich/ubuntu/mpich-3.1/mpich_3.1-1ubuntu_amd64.deb
-  # - sudo dpkg -i mpich_3.1-1ubuntu_amd64.deb || true
-  # - sudo apt-get -f install -y
+  ### stupid hack to get a modern version of cmake
+  - wget -q http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz;
+  - ln -s /usr/local ./cmake-3.2.3-Linux-x86_64
+  - sudo tar xzf ./cmake-3.2.3-Linux-x86_64.tar.gz
+  - rm -f ./cmake-3.2.3-Linux-x86_64.tar.gz
+before_script:
+  - export MPIEXEC='mpiexec -launcher fork'
 script:
   - "./configure && cd build/Make+Release && make -j1 VERBOSE=1 check-all-pass-compile-only"
 branches:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,8 @@ endif()
 set(Boost_USE_MULTITHREADED OFF)
 
 # CMake 2.8 doesn't list most recent Boost versions, so add them ourselves
-set(Boost_ADDITIONAL_VERSIONS "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57")
+set(Boost_ADDITIONAL_VERSIONS "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56"
+  "1.55.0" "1.55" "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51")
 
 # first, search for things that we'd prefer to be static
 if(VERBOSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ if(Boost_FOUND)
   set(Boost_STATIC_LIBRARIES "${Boost_LIBRARIES}")
 else()
   # if that didn't work, re-search for dynamic versions
-  message("-- Searching for static Boost components: ${BOOST_STATIC_OR_DYNAMIC_COMPONENTS}")
+  message("-- Searching for dynamic Boost components: ${BOOST_STATIC_OR_DYNAMIC_COMPONENTS}")
   # we turned off Boost_USE_STATIC_LIBS above
   set(BOOST_COMPONENTS_TO_FIND ${BOOST_STATIC_OR_DYNAMIC_COMPONENTS})
   grappa_search_for_boost()

--- a/util/grappa.cmake
+++ b/util/grappa.cmake
@@ -31,7 +31,7 @@ macro(grappa_search_for_boost)
   # if boost was not found in third-party, restore any user-specified pointers and search there and in standard paths
   #
   if(NOT Boost_FOUND)
-    
+
     # restore any user-specified pointers
     if(Boost_NO_SYSTEM_PATHS_BACKUP)
       set(Boost_NO_SYSTEM_PATHS ${Boost_NO_SYSTEM_PATHS_BACKUP})
@@ -41,6 +41,7 @@ macro(grappa_search_for_boost)
     if(BOOSTROOT_BACKUP)
       set(BOOSTROOT ${BOOSTROOT_BACKUP})
     endif()
+    unset(BOOST_ROOT)
     if(BOOST_ROOT_BACKUP)
       set(BOOST_ROOT ${BOOST_ROOT_BACKUP})
     endif()


### PR DESCRIPTION
This stopped working when I improved the build system earlier this year. The main problem was just that Travis' default version of CMake was older than what we require.