### PR TITLE
Fix third-party build?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if(GRAPH500_FOUND)
   list(APPEND GRAPPA_STATIC_LIBS ${GRAPH500_FOUND})
 else()
   # assume it will be built in third-party
-  list(APPEND GRAPPA_STATIC_LIBS ${THIRD_PARTY_ROOT}/graph500-generator/libgraph500-generator.a)
+  list(APPEND GRAPPA_STATIC_LIBS ${CMAKE_BINARY_DIR}/third-party/graph500-generator/libgraph500-generator.a)
 endif()
 
 ######################################################################


### PR DESCRIPTION
In attempting to fix the grappa-docker build, I found that I needed to change this reference because building third-party doesn’t actually install graph500-generator externally in THIRD_PARTY_ROOT.

I’m curious how this hasn’t broken things for normal use elsewhere, @nelsonje? Do you usually not use a separate third-party build?