### PR TITLE
fix memset & posix_memalign compiler warnings

### DIFF
--- a/system/ChunkAllocator.cpp
+++ b/system/ChunkAllocator.cpp
@@ -95,9 +95,6 @@ static void _aligned_allocator_append_chunk(struct aligned_allocator *aa,
     auto chunk_size = sizeof(new_chunk->chunk_size);
     shared_pool_total_allocated += std::max( new_chunk->chunk_size, (decltype(chunk_size)) CACHE_LINE_SIZE );
     
-    // for timing only
-    memset(new_chunk->chunk, 0, new_chunk->chunk_size);
-    
     if (!aa->first)
         aa->last = aa->first = new_chunk;
     else {

--- a/system/ChunkAllocator.cpp
+++ b/system/ChunkAllocator.cpp
@@ -96,7 +96,7 @@ static void _aligned_allocator_append_chunk(struct aligned_allocator *aa,
     shared_pool_total_allocated += std::max( new_chunk->chunk_size, (decltype(chunk_size)) CACHE_LINE_SIZE );
     
     // for timing only
-    memset(new_chunk->chunk, new_chunk->chunk_size, 0);
+    memset(new_chunk->chunk, 0, new_chunk->chunk_size);
     
     if (!aa->first)
         aa->last = aa->first = new_chunk;

--- a/system/NTBuffer.hpp
+++ b/system/NTBuffer.hpp
@@ -102,7 +102,8 @@ public:
   }
 
   void new_buffer( ) {
-    posix_memalign( reinterpret_cast<void**>(&buffer_), 64, BUFFER_SIZE );
+    CHECK( posix_memalign( reinterpret_cast<void**>(&buffer_), 64, BUFFER_SIZE ) == 0)
+      << "posix_memalign error: buffer allocation failed";
     position_ = 0;
   }
   

--- a/system/Worker.cpp
+++ b/system/Worker.cpp
@@ -177,7 +177,9 @@ Worker * worker_spawn(Worker * me, Scheduler * sched, thread_func f, void * arg)
  
   // allocate the Worker and stack
   Worker * thr = nullptr;
-  posix_memalign( reinterpret_cast<void**>( &thr ), 4096, sizeof(Worker) );
+  CHECK( posix_memalign( reinterpret_cast<void**>( &thr ), 4096, sizeof(Worker) ) == 0)
+    << "posix_memalign error: Worker allocation failed";
+  
   thr->sched = sched;
   sched->assignTid( thr );
   


### PR DESCRIPTION
As long as I’m making pull requests I may as well do this nit-picky one. I was irked by the compiler warnings when building with Ninja (they probably just get drowned out when building with Make), and who knows, these could come back to bite us someday.