### PR TITLE
Fixing a few bugs in unit tests

### DIFF
--- a/applications/join/CMakeLists.txt
+++ b/applications/join/CMakeLists.txt
@@ -147,8 +147,9 @@ macro(add_check test_cpp nnode ppn target)
 
   add_grappa_test(${test} ${nnode} ${ppn} ${test_cpp})
   target_link_libraries(${test} generator queryio)
-  add_dependencies( check-all-${target} check-${test_name} )
-  add_dependencies( check-all-${target}-compile-only ${test})
+  ### TODO: add separate check-all-join-* targets to include these application files
+  ###add_dependencies( check-all-${target} check-${test_name} )
+  ###add_dependencies( check-all-${target}-compile-only ${test})
 endmacro()
 
 add_check(Relation_io_tests.cpp 2 1 pass)

--- a/system/GlobalCounter.hpp
+++ b/system/GlobalCounter.hpp
@@ -59,7 +59,7 @@ public:
   };
   FlatCombiner<Proxy> comb;
     
-  GlobalCounter(long initial_count = 0, Core master_core = 0): comb(locale_new<Proxy>(this)) {
+  GlobalCounter(GlobalAddress<GlobalCounter> self, long initial_count = 0, Core master_core = 0): self(self), comb(locale_new<Proxy>(this)) {
     master.count = initial_count;
     master.core = master_core;
   }
@@ -79,7 +79,7 @@ public:
   static GlobalAddress<GlobalCounter> create(long initial_count = 0) {
     auto a = symmetric_global_alloc<GlobalCounter>();
     auto master_core = mycore();
-    call_on_all_cores([a,master_core]{ new (a.localize()) GlobalCounter(0, master_core); });
+    call_on_all_cores([a,initial_count,master_core]{ new (a.localize()) GlobalCounter(a, initial_count, master_core); });
     return a;
   }
   


### PR DESCRIPTION
Here are some simple fixes to some test bugs as we've discussed over the last few days. 

@bmyerz note that I'm removing the Relation IO tests from the check-all-pass and check-all-pass-compile-only targets for now; it seems that the test appends to some file without an initial truncation so it runs correctly the first time and then fails whenever you run it after that. Since this isn't a core part of Grappa I think we should keep its tests separate anyway.