### PR TITLE
Mitigation for a scaling problem

### DIFF
--- a/system/tasks/Task.hpp
+++ b/system/tasks/Task.hpp
@@ -268,7 +268,7 @@ class TaskManager {
 
 /// Whether work possibly exists locally or globally
 inline bool TaskManager::available( ) const {
-  VLOG(6) << " publicHasEle()=" << publicHasEle()
+  DVLOG(6) << " publicHasEle()=" << publicHasEle()
     << " privateHasEle()=" << privateHasEle();
   return privateHasEle() 
     || publicHasEle()
@@ -279,7 +279,7 @@ inline bool TaskManager::available( ) const {
 
 /// Whether work exists locally
 inline bool TaskManager::local_available( ) const {
-  VLOG(6) << " publicHasEle()=" << publicHasEle()
+  DVLOG(6) << " publicHasEle()=" << publicHasEle()
     << " privateHasEle()=" << privateHasEle();
   return privateHasEle() 
     || publicHasEle();

--- a/system/tasks/TaskingScheduler.cpp
+++ b/system/tasks/TaskingScheduler.cpp
@@ -38,7 +38,9 @@
 #include "../PerformanceTools.hpp"
 
 /// TODO: this should be based on some actual time-related metric so behavior is predictable across machines
-DEFINE_int64( periodic_poll_ticks, 20000, "number of ticks to wait before polling periodic queue");
+DEFINE_int64( periodic_poll_ticks,          0, "number of ticks to wait before polling periodic queue for one core (set to 0 for auto-growth)");
+DEFINE_int64( periodic_poll_ticks_base, 28000, "number of ticks to wait before polling periodic queue for one core (see _growth for increase)");
+DEFINE_int64( periodic_poll_ticks_growth, 281, "number of ticks to add per core");
 
 DEFINE_bool(poll_on_idle, true, "have tasking layer poll aggregator if it has nothing better to do");
 
@@ -82,6 +84,7 @@ TaskingScheduler global_scheduler;
   , num_workers ( 0 )
   , work_args( NULL )
   , previous_periodic_ts( 0 ) 
+  , periodic_poll_ticks( 0 ) 
   , in_no_switch_region_( false )
   , prev_ts( 0 )
   , prev_stats_blob_ts( 0 )
@@ -98,6 +101,14 @@ void TaskingScheduler::init ( Worker * master_arg, TaskManager * taskman ) {
   current_thread = master;
   task_manager = taskman;
   work_args = new task_worker_args( taskman, this );
+  if( 0 == FLAGS_periodic_poll_ticks ) {
+    periodic_poll_ticks = FLAGS_periodic_poll_ticks_base + global_communicator.cores * FLAGS_periodic_poll_ticks_growth;
+    if( 0 == global_communicator.mycore ) {
+      VLOG(2) << "Actual periodic poll ticks value is " << periodic_poll_ticks;
+    }
+  } else {
+    periodic_poll_ticks = FLAGS_periodic_poll_ticks;
+  }
 }
 
 /// Give control to the scheduler until task layer

--- a/system/tasks/TaskingScheduler.hpp
+++ b/system/tasks/TaskingScheduler.hpp
@@ -129,8 +129,9 @@ class TaskingScheduler : public Scheduler {
 
     // STUB: replace with real periodic threads
     Grappa::Timestamp previous_periodic_ts;
+    Grappa::Timestamp periodic_poll_ticks;
   inline bool should_run_periodic( Grappa::Timestamp current_ts ) {
-    return current_ts - previous_periodic_ts > FLAGS_periodic_poll_ticks;
+    return current_ts - previous_periodic_ts > periodic_poll_ticks;
   }
 
     Worker * periodicDequeue(Grappa::Timestamp current_ts) {
@@ -379,7 +380,8 @@ class TaskingScheduler : public Scheduler {
     void periodic( Worker * thr ) {
       periodicQ.enqueue( thr );
       Grappa::tick();
-      previous_periodic_ts = Grappa::timestamp();
+      Grappa::Timestamp current_ts = Grappa::force_tick();
+      previous_periodic_ts = current_ts;
     }
 
     /// Reset scheduler statistics


### PR DESCRIPTION
It turns out that as the core count grows, the time it takes to do one wakeup of the polling worker increases, eventually to the point where by the time it's done, it's time to wake it up again. Thus, compute workers get starved.

This is a temporary fix that scales the poll timeout with the number of cores to try to avoid this problem. It also counts ticks from the end of polling worker execution, rather than the beginning. It works okay for the cluster sizes I can get at PNNL; we'll see how it does on bigger machines.

You can override the autoscaling by specifying --periodic_poll_ticks just as in the past.

What we should really do here is to use the time it actually takes to run the polling thread to set the timeout, through some sort of dynamic feedback mechanism. I don't have time to do that now, so I'll merge this and add an issue. 