### PR TITLE
convert some macros to constants to avoid conflicts 

### DIFF
--- a/applications/join/DoubleDHT.hpp
+++ b/applications/join/DoubleDHT.hpp
@@ -218,7 +218,7 @@ class DoubleDHT {
         if (lookup_local_right( key, target.pointer(), &e)) {
           auto resultsptr = e.vs;
           // Critical for correctness: uses the current size of the vector, so later inserts are not used
-          Grappa::forall_here<async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
+          Grappa::forall_here<Grappa::async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
             for  (int64_t i=start; i<start+iters; i++) {
               auto results = *resultsptr;
               // call the continuation with the lookup result
@@ -257,7 +257,7 @@ class DoubleDHT {
         if (lookup_local_left( key, target.pointer(), &e)) {
           auto resultsptr = e.vs;
           // Critical for correctness: uses the current size of the vector, so later inserts are not used
-          Grappa::forall_here<async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
+          Grappa::forall_here<Grappa::async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
             for  (int64_t i=start; i<start+iters; i++) {
               auto results = *resultsptr;
               // call the continuation with the lookup result
@@ -285,7 +285,7 @@ class DoubleDHT {
       uint64_t index = computeIndex( key );
       GlobalAddress< PairCell > target = base + index; 
 
-      Grappa::delegate::call<async, GCE>( target.core(), [key, target, val, f]() {
+      Grappa::delegate::call<Grappa::async, GCE>( target.core(), [key, target, val, f]() {
         // this is atomic { insert_local; lookup_local }
         insert_local<D, VIns>( key, target.pointer(), val );
 

--- a/applications/join/HashJoin.hpp
+++ b/applications/join/HashJoin.hpp
@@ -49,7 +49,7 @@ void freeJoinReducers(GlobalAddress<JoinReducer<K,VL,VR,OutType>> reducers, size
 
 template <typename K, typename VL, typename VR, typename OutType, Grappa::GlobalCompletionEvent * GCE = &default_join_left_gce>
 static void reducer_append_left( GlobalAddress<JoinReducer<K,VL,VR,OutType>> r, K key, VL val ) {
-  Grappa::delegate::call<async, GCE>(r.core(), [=] {
+  Grappa::delegate::call<Grappa::async, GCE>(r.core(), [=] {
     VLOG(5) << "add (" << key << ", " << val << ") at " << r.pointer();
     std::vector<VL>& slot = (*(r->groupsL))[key];
     slot.push_back(val);
@@ -58,7 +58,7 @@ static void reducer_append_left( GlobalAddress<JoinReducer<K,VL,VR,OutType>> r, 
 
 template <typename K, typename VL, typename VR, typename OutType, Grappa::GlobalCompletionEvent * GCE = &default_join_right_gce>
 static void reducer_append_right( GlobalAddress<JoinReducer<K,VL,VR,OutType>> r, K key, VR val ) {
-  Grappa::delegate::call<async, GCE>(r.core(), [=] {
+  Grappa::delegate::call<Grappa::async, GCE>(r.core(), [=] {
     VLOG(5) << "add (" << key << ", " << val << ") at " << r.pointer();
     std::vector<VR>& slot = (*(r->groupsR))[key];
     slot.push_back(val);

--- a/applications/join/HashSet.hpp
+++ b/applications/join/HashSet.hpp
@@ -130,7 +130,7 @@ class HashSet {
       uint64_t index = computeIndex( key );
       GlobalAddress< Cell > target = base + index; 
 
-      Grappa::delegate::call<async,GCE>(target.core(), [key,target]() {
+      Grappa::delegate::call<Grappa::async,GCE>(target.core(), [key,target]() {
 
         Cell * c = target.pointer();
         

--- a/applications/join/MapReduce.hpp
+++ b/applications/join/MapReduce.hpp
@@ -26,7 +26,7 @@ void forall_symmetric(GlobalAddress<RandomAccess> vs, AF accessor, CF f ) {
   Grappa::on_all_cores([=] {
       //VLOG(1) << "size = " << accessor(vs).size();
       auto local_vs = accessor(vs);
-      Grappa::forall_here<async,GCE>(0, local_vs.size(), [=](int64_t start, int64_t iters) {
+      Grappa::forall_here<Grappa::async,GCE>(0, local_vs.size(), [=](int64_t start, int64_t iters) {
         for (int i=start; i<start+iters; i++) {
           auto e = local_vs[i];
           f(e);
@@ -50,7 +50,7 @@ struct Reducer {
 
 template <typename K, typename V, typename OutType, Grappa::GlobalCompletionEvent * GCE = &default_mr_gce>
 void reducer_append( GlobalAddress<Reducer<K,V,OutType>> r, K key, V val ) {
-  Grappa::delegate::call<async, GCE>(r.core(), [=] {
+  Grappa::delegate::call<Grappa::async, GCE>(r.core(), [=] {
     VLOG(5) << "add (" << key << ", " << val << ") at " << r.pointer();
     std::vector<V>& slot = (*(r->groups))[key];
     slot.push_back(val);

--- a/applications/join/MatchesDHT.hpp
+++ b/applications/join/MatchesDHT.hpp
@@ -202,7 +202,7 @@ class MatchesDHT {
         Entry e;
         if (lookup_local( key, target.pointer(), &e)) {
           auto resultsptr = e.vs;
-          Grappa::forall_here<async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
+          Grappa::forall_here<Grappa::async,GCE>(0, e.vs->size(), [f,resultsptr](int64_t start, int64_t iters) {
             for  (int64_t i=start; i<start+iters; i++) {
               auto results = *resultsptr;
               // call the continuation with the lookup result
@@ -223,7 +223,7 @@ class MatchesDHT {
       uint64_t index = computeIndex( key );
       GlobalAddress< Cell > target = base + index; 
 
-      Grappa::delegate::call<async>( target.core(), [key, target, f]() {
+      Grappa::delegate::call<Grappa::async>( target.core(), [key, target, f]() {
         hash_called_lookups++;
         Entry e;
         if (lookup_local( key, target.pointer(), &e)) {
@@ -285,7 +285,7 @@ class MatchesDHT {
       } else {
         hash_remote_inserts++;
       }
-      Grappa::delegate::call<async, GCE>( target.core(), [key, val, target]() {   // TODO: upgrade to call_async; using GCE
+      Grappa::delegate::call<Grappa::async, GCE>( target.core(), [key, val, target]() {   // TODO: upgrade to call_async; using GCE
         hash_called_inserts++;
 
         // list of entries in this cell

--- a/applications/join/relation_io.hpp
+++ b/applications/join/relation_io.hpp
@@ -112,7 +112,7 @@ tuple_graph readEdges( std::string fn, int64_t numTuples ) {
 
       // write edge to location
       int myindex = fin++;
-      Grappa::delegate::write<async>(edges+myindex, pe);
+      Grappa::delegate::write<Grappa::async>(edges+myindex, pe);
     }
   });
 

--- a/applications/join/triangles.OldDHT.cpp
+++ b/applications/join/triangles.OldDHT.cpp
@@ -170,7 +170,7 @@ void join2( GlobalAddress<Tuple> tuples, Column ji1, Column ji2, Column ji3 ) {
     DVLOG(4) << "key " << *t << " finds (" << results << ", " << num_results << ")";
     
     async_parallel_for<Tuple, secondJoin, joinerSpawn<Tuple,secondJoin,ASYNC_PAR_FOR_DEFAULT>, ASYNC_PAR_FOR_DEFAULT >( results, num_results );
-    forall_here<unbound,async>(resultsIndex, num_results 
+    forall_here<Grappa::unbound,Grappa::async>(resultsIndex, num_results 
 
     });
 

--- a/applications/sort/grappa/main.cpp
+++ b/applications/sort/grappa/main.cpp
@@ -38,7 +38,7 @@ static const size_t BUFSIZE = 1L<<22;
 
 // little helper for iterating over things numerous enough to need to be buffered
 #define for_buffered(i, n, start, end, nbuf) \
-  for (size_t i=start, n=nbuf; i<end && (n = MIN(nbuf, end-i)); i+=nbuf)
+  for (size_t i=start, n=nbuf; i<end && (n = std::min(nbuf, end-i)); i+=nbuf)
 
 
 static void printHelp(const char * exe);

--- a/applications/sort/grappa/sort.hpp
+++ b/applications/sort/grappa/sort.hpp
@@ -37,7 +37,7 @@ static const size_t BUFSIZE = 1L<<22;
 
 // little helper for iterating over things numerous enough to need to be buffered
 #define for_buffered(i, n, start, end, nbuf) \
-  for (size_t i=start, n=nbuf; i<end && (n = MIN(nbuf, end-i)); i+=nbuf)
+  for (size_t i=start, n=nbuf; i<end && (n = std::min(nbuf, end-i)); i+=nbuf)
 
 namespace Grappa {
   template<typename T>

--- a/system/ChunkAllocator.cpp
+++ b/system/ChunkAllocator.cpp
@@ -99,7 +99,7 @@ static void _aligned_allocator_append_chunk(struct aligned_allocator *aa,
     chunkallocator_allocated += std::max( chunk_struct_size, (decltype(chunk_struct_size)) CACHE_LINE_SIZE );
     
     new_chunk->next = NULL;
-    new_chunk->chunk_size = MAX(min_size, aa->chunk_size) + aa->align_on;
+    new_chunk->chunk_size = std::max(min_size, aa->chunk_size) + aa->align_on;
     new_chunk->chunk = Grappa::locale_alloc_aligned<char>(CACHE_LINE_SIZE, new_chunk->chunk_size);
     CHECK_NOTNULL(new_chunk->chunk);
 
@@ -152,7 +152,7 @@ void aligned_pool_allocator_init(struct aligned_pool_allocator *apa,
                                  size_t object_size,
                                  u_int64_t chunk_count) {
     int i;
-    object_size = MAX(object_size, sizeof(void *));
+    object_size = std::max(object_size, sizeof(void *));
     apa->aa = aligned_allocator_create();
     aligned_allocator_init(apa->aa, align_on, object_size * chunk_count);
     for (i = 0; i < ALLOCATOR_PREFETCH_DISTANCE; i++)

--- a/system/Grappa.hpp
+++ b/system/Grappa.hpp
@@ -88,7 +88,7 @@ namespace Grappa {
   ///   forall<unbound>(...)
   ///   forall<unbound,async>(...)
   /// @endcode
-  #define unbound Grappa::TaskMode::Unbound
+  const auto unbound = Grappa::TaskMode::Unbound;
 #endif
   
 #ifndef GRAPPA_NO_ABBREV
@@ -99,7 +99,7 @@ namespace Grappa {
   ///   delegate::call<async>(...)
   ///   delegate::write<async>(...)
   /// @endcode
-  #define async Grappa::SyncMode::Async
+  const auto async = Grappa::SyncMode::Async;
 #endif
   
 }

--- a/system/Gups_tests.cpp
+++ b/system/Gups_tests.cpp
@@ -107,9 +107,9 @@ BOOST_AUTO_TEST_CASE( test1 ) {
 
       // best with loop threshold 1024
       // shared pool size 2^16
-      Grappa::forall<unbound>( 0, FLAGS_iterations-1, [A] ( int64_t i ) {
+      Grappa::forall<Grappa::unbound>( 0, FLAGS_iterations-1, [A] ( int64_t i ) {
           uint64_t b = (i * LARGE_PRIME) % FLAGS_sizeA;
-          Grappa::delegate::increment<async>( A + b, 1 );
+          Grappa::delegate::increment<Grappa::async>( A + b, 1 );
         } );
 
       double end = Grappa::walltime();

--- a/system/common.hpp
+++ b/system/common.hpp
@@ -60,10 +60,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 #include <cstddef>
 using std::nullptr_t;
 
-#if defined(__MTA__)
-#include <sys/mta_task.h>
-#include <machine/runtime.h>
-#elif defined(__MACH__)
+#if defined(__MACH__)
 #include <mach/mach_time.h>
 #else
 #include <time.h>
@@ -106,11 +103,9 @@ namespace Grappa {
   enum class SyncMode { Blocking /*default*/, Async };
     
   
-/// "Universal" wallclock time (works at least for Mac, MTA, and most Linux)
+/// "Universal" wallclock time (works at least for Mac, and most Linux)
 inline double walltime(void) {
-#if defined(__MTA__)
-	return((double)mta_get_clock(0) / mta_clock_freq());
-#elif defined(__MACH__)
+#if defined(__MACH__)
 	static mach_timebase_info_data_t info;
 	mach_timebase_info(&info);
 	uint64_t now = mach_absolute_time();

--- a/system/common.hpp
+++ b/system/common.hpp
@@ -78,13 +78,6 @@ using std::nullptr_t;
 #define MILLION         (1000ULL * THOUSAND)
 #define BILLION         (1000ULL * MILLION)
 
-#ifndef MAX
-#  define MAX(a,b) ((a) < (b) ? (b) : (a))
-#endif
-#ifndef MIN
-#  define MIN(a,b) ((a) > (b) ? (b) : (a))
-#endif
-
 // align ptr x to y boundary (rounding up)
 #define ALIGN_UP(x, y) \
     ((((u_int64_t)(x) & (((u_int64_t)(y))-1)) != 0) ? \

--- a/system/graph/TupleGraph.cpp
+++ b/system/graph/TupleGraph.cpp
@@ -219,14 +219,14 @@ TupleGraph TupleGraph::load_tsv( std::string path ) {
   on_all_cores( [=] {
       Edge * local_ptr = edges.localize();
       Edge * local_end = (edges+nedge).localize();
-      auto local_count = local_end - local_ptr;
-      auto read_count = read_edges.size();
+      size_t local_count = local_end - local_ptr;
+      size_t read_count = read_edges.size();
 
       DVLOG(7) << "local_count " << local_count
                << " read_count " << read_count;
       
       // copy everything in our read buffer that fits locally
-      auto local_max = MIN( local_count, read_count );
+      auto local_max = std::min( local_count, read_count );
       std::memcpy( local_ptr, &read_edges[0], local_max * sizeof(Edge) );
       local_offset = local_max;
       Grappa::barrier();
@@ -476,14 +476,14 @@ TupleGraph TupleGraph::load_mm( std::string path ) {
   on_all_cores( [=] {
       Edge * local_ptr = edges.localize();
       Edge * local_end = (edges+nedge).localize();
-      auto local_count = local_end - local_ptr;
-      auto read_count = read_edges.size();
+      size_t local_count = local_end - local_ptr;
+      size_t read_count = read_edges.size();
 
       DVLOG(7) << "local_count " << local_count
                << " read_count " << read_count;
       
       // copy everything in our read buffer that fits locally
-      auto local_max = MIN( local_count, read_count );
+      auto local_max = std::min( local_count, read_count );
       std::memcpy( local_ptr, &read_edges[0], local_max * sizeof(Edge) );
       local_offset = local_max;
       Grappa::barrier();


### PR DESCRIPTION
I ran into some name aliasing with some Cray code, so I'm converting the ```async``` and ```unbound``` macros to constants in the Grappa namespace.

For some existing code that doesn't do "using namespace grappa;", we need to add a ```Grappa::``` prefix to uses of these values. @bmyerz, I need your help to make sure I didn't screw up anything in ```applications/join``` when making these changes; I don't know how to build everything there.