### PR TITLE
Once again, fixing Travis CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
       ### get a modern version of MPI
       wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
       tar xzf mpich-3.2.tar.gz
-      cd mpich-3.2 && ./configure --disable-fortran --prefix=$HOME/installed && make -j2 && make install
+      (cd mpich-3.2 && ./configure --disable-fortran --prefix=$HOME/installed && make -j2 && make install)
     else
       echo 'Using cached dependences.'
     fi
@@ -50,7 +50,7 @@ before_script:
   
 script:
   - ./configure
-  - cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only
+  - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ sudo: false
 language: cpp
 
 compiler:
-  - gcc
+  - clang
 
 addons:
   apt:
     sources:
     - boost-latest
-    - ubuntu-toolchain-r-test
     packages:
     - libboost-date-time1.55-dev
     - libboost-exception1.55-dev
@@ -23,8 +22,6 @@ addons:
     - libboost-system1.55-dev
     - libboost-test1.55-dev
     - libboost-timer1.55-dev
-    - gcc-4.9
-    - g++-4.9
 
 cache:
   apt: true
@@ -35,8 +32,6 @@ install:
   - |
     if [ ! -d "$HOME/installed/bin" ]; then
       set -e
-      export CC=gcc-4.9
-      export CXX=g++-4.9
       ### create a place to hold our local dependences
       mkdir -p $HOME/installed
       ### get a modern version of CMake
@@ -51,8 +46,6 @@ install:
     fi
   
 before_script:
-  - export CC=gcc-4.9
-  - export CXX=g++-4.9
   - export PATH="$HOME/installed/bin:$PATH"
   
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,68 @@
+sudo: false
+
 language: cpp
+
 compiler:
-  - clang
-# - gcc
-# before_install:
-#   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-#   - sudo apt-get update -qq
-#   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.7; fi
-#   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
-before_install:
-  ### add PPA for modern version of boost
-  - sudo add-apt-repository ppa:boost-latest/ppa -y
-  - sudo apt-get update -q
-  ### install boost and other necessary packages
-  - sudo apt-get install -q gfortran libcr0 default-jdk libboost1.54-all-dev
-  ### get an MPI that supports MPI-3 
-  - wget --no-check-certificate -q http://www.cebacad.net/files/mpich/ubuntu/mpich-3.1/mpich_3.1-1ubuntu_amd64.deb;
-  - sudo dpkg -i ./mpich_3.1-1ubuntu_amd64.deb
-  - rm -f ./mpich_3.1-1ubuntu_amd64.deb
-  ### stupid hack to get a modern version of cmake
-  - wget --no-check-certificate -q http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz;
-  - ln -s /usr/local ./cmake-3.2.3-Linux-x86_64
-  - sudo tar xzf ./cmake-3.2.3-Linux-x86_64.tar.gz
-  - rm -f ./cmake-3.2.3-Linux-x86_64.tar.gz
+  - gcc
+
+addons:
+  apt:
+    sources:
+    - boost-latest
+    - ubuntu-toolchain-r-test
+    packages:
+    - libboost-date-time1.55-dev
+    - libboost-exception1.55-dev
+    - libboost-filesystem1.55-dev
+    - libboost-iostreams1.55-dev
+    - libboost-math1.55-dev
+    - libboost-random1.55-dev
+    - libboost-regex1.55-dev
+    - libboost-serialization1.55-dev
+    - libboost-signals1.55-dev
+    - libboost-system1.55-dev
+    - libboost-test1.55-dev
+    - libboost-timer1.55-dev
+    - gcc-4.9
+    - g++-4.9
+
+cache:
+  apt: true
+  directories:
+    - $HOME/installed
+    
+install:
+  - |
+    if [ ! -d "$HOME/installed/bin" ]; then
+      set -e
+      export CC=gcc-4.9
+      export CXX=g++-4.9
+      ### create a place to hold our local dependences
+      mkdir -p $HOME/installed
+      ### get a modern version of CMake
+      wget --no-check-certificate -q http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz;
+      tar xzf cmake-3.2.3-Linux-x86_64.tar.gz  -C $HOME/installed --strip-components=1
+      ### get a modern version of MPI
+      wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
+      tar xzf mpich-3.2.tar.gz
+      cd mpich-3.2 && ./configure --disable-fortran --prefix=$HOME/installed && make -j2 && make install
+    else
+      echo 'Using cached dependences.'
+    fi
+  
 before_script:
-  - export MPIEXEC='mpiexec -launcher fork'
+  - export CC=gcc-4.9
+  - export CXX=g++-4.9
+  - export PATH="$HOME/installed/bin:$PATH"
+  
 script:
-  - "./configure && cd build/Make+Release && make -j1 VERBOSE=1 check-all-pass-compile-only"
+  - ./configure
+  - cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only
+
 branches:
   only:
     - master
+
 notifications:
   irc:
     channels: "chat.freenode.net#grappa.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ before_install:
   ### install boost and other necessary packages
   - sudo apt-get install -q gfortran libcr0 default-jdk libboost1.54-all-dev
   ### get an MPI that supports MPI-3 
-  - wget -q http://www.cebacad.net/files/mpich/ubuntu/mpich-3.1/mpich_3.1-1ubuntu_amd64.deb;
+  - wget --no-check-certificate -q http://www.cebacad.net/files/mpich/ubuntu/mpich-3.1/mpich_3.1-1ubuntu_amd64.deb;
   - sudo dpkg -i ./mpich_3.1-1ubuntu_amd64.deb
   - rm -f ./mpich_3.1-1ubuntu_amd64.deb
   ### stupid hack to get a modern version of cmake
-  - wget -q http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz;
+  - wget --no-check-certificate -q http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz;
   - ln -s /usr/local ./cmake-3.2.3-Linux-x86_64
   - sudo tar xzf ./cmake-3.2.3-Linux-x86_64.tar.gz
   - rm -f ./cmake-3.2.3-Linux-x86_64.tar.gz


### PR DESCRIPTION
I managed to fix Travis errors and move to their new build infrastructure. Details:
* The previous failures came from some dependences redirecting http links to https, and wget not being willing to follow them without having certificates installed in the image. I told wget to ignore this validation step.
* Due to the lack of root access, I'm now building MPICH from scratch instead of downloading and installing a ```.deb```. I'm still downloading and installing a binary CMake. Fortunately, both of these installations are cached by Travis CI
* I'm installing a subset of boost to avoid conflicts between the system MPI (that gets installed by libboost-all-dev) and the MPI I build.
* I tried switching to GCC 4.9, but Clang is faster (current build takes ~3:30 instead of ~5:20)