### PR TITLE
Matrix Market files use 1-indexed coordinate entries

### DIFF
--- a/system/graph/TupleGraph.cpp
+++ b/system/graph/TupleGraph.cpp
@@ -292,7 +292,7 @@ TupleGraph TupleGraph::load_tsv( std::string path ) {
 }
 
 /// Matrix Market format loader
-TupleGraph TupleGraph::load_mm( std::string path ) {
+TupleGraph TupleGraph::load_mm( std::string path, bool one_indexed = true ) {
   // make sure file exists
   CHECK( fs::exists( path ) ) << "File not found.";
   CHECK( fs::is_regular_file( path ) ) << "File is not a regular file.";
@@ -442,8 +442,10 @@ TupleGraph TupleGraph::load_mm( std::string path ) {
           std::getline( infile, str );
         } else {
           infile >> v0;
+          if(one_indexed) v0--;
           if( !infile.good() ) break;
           infile >> v1;
+          if(one_indexed) v1--;
           if( header_info.field_double ) {
             double d;
             infile >> d;


### PR DESCRIPTION
The Matrix Market format specifies that coordinates are 1-indexed. However, it is unclear if everyone follows this rule. I added a flag to switch 1-indexing on and off in the Matrix Market parser.