### PR TITLE
Invoke Doxygen build on Travis CI success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,15 @@ script:
   - ./configure
   - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
-after_success:
-  - >
-  curl -v -s -X POST
-      -H "Content-Type: application/json"
-      -H "Accept: application/json"
-      -H "Travis-API-Version: 3"
-      -H "Authorization: token ${TRAVISCI_TOKEN}"
-      -d '{ "request": { "branch": "master" } }'
-        https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
+# after_success:
+#   - >
+#     curl -v -s -X POST
+#       -H "Content-Type: application/json"
+#       -H "Accept: application/json"
+#       -H "Travis-API-Version: 3"
+#       -H "Authorization: token ${TRAVISCI_TOKEN}"
+#       -d '{ "request": { "branch": "master" } }'
+#         https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,16 @@ script:
   - ./configure
   - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
+after_success:
+  - |
+  curl -v -s -X POST \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -H "Travis-API-Version: 3" \
+      -H "Authorization: token ${TRAVISCI_TOKEN}" \
+      -d '{ "request": { "branch": "master" } }' \
+        https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ script:
 after_success:
   - >
     curl -v -s -X POST
-      -H "Content-Type: application/json"
-      -H "Accept: application/json"
-      -H "Travis-API-Version: 3"
-      -H "Authorization: token ${TRAVISCI_TOKEN}"
-      -d '{ "request": { "branch": "master" } }'
-        https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
+    -H "Content-Type: application/json"
+    -H "Accept: application/json"
+    -H "Travis-API-Version: 3"
+    -H "Authorization: token ${TRAVISCI_TOKEN}"
+    -d '{ "request": { "branch": "master" } }'
+    https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,9 @@ script:
   - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
 after_success:
+  ### fire off web documentation build if this change modified master
   - >
+    [ "${TRAVIS_PULL_REQUEST}" = "false" && "${TRAVIS_BRANCH}" = "master" ] &&
     curl -v -s -X POST
     -H "Content-Type: application/json"
     -H "Accept: application/json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,12 @@ script:
 
 after_success:
   - >
-      curl -v -s -X POST
-        -H "Content-Type: application/json"
-        -H "Accept: application/json"
-        -H "Travis-API-Version: 3"
-        -H "Authorization: token ${TRAVISCI_TOKEN}"
-        -d '{ "request": { "branch": "master" } }'
+    curl -v -s -X POST
+      -H "Content-Type: application/json"
+      -H "Accept: application/json"
+      -H "Travis-API-Version: 3"
+      -H "Authorization: token ${TRAVISCI_TOKEN}"
+      -d '{ "request": { "branch": "master" } }'
         https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,13 @@ script:
   - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
 after_success:
-  - |
-  curl -v -s -X POST \
-      -H "Content-Type: application/json" \
-      -H "Accept: application/json" \
-      -H "Travis-API-Version: 3" \
-      -H "Authorization: token ${TRAVISCI_TOKEN}" \
-      -d '{ "request": { "branch": "master" } }' \
+  - >
+  curl -v -s -X POST
+      -H "Content-Type: application/json"
+      -H "Accept: application/json"
+      -H "Travis-API-Version: 3"
+      -H "Authorization: token ${TRAVISCI_TOKEN}"
+      -d '{ "request": { "branch": "master" } }'
         https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,15 @@ script:
   - ./configure
   - (cd build/Make+Release && make VERBOSE=1 -j2 check-all-pass-compile-only)
 
-# after_success:
-#   - >
-#     curl -v -s -X POST
-#       -H "Content-Type: application/json"
-#       -H "Accept: application/json"
-#       -H "Travis-API-Version: 3"
-#       -H "Authorization: token ${TRAVISCI_TOKEN}"
-#       -d '{ "request": { "branch": "master" } }'
-#         https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
+after_success:
+  - >
+      curl -v -s -X POST
+        -H "Content-Type: application/json"
+        -H "Accept: application/json"
+        -H "Travis-API-Version: 3"
+        -H "Authorization: token ${TRAVISCI_TOKEN}"
+        -d '{ "request": { "branch": "master" } }'
+        https://api.travis-ci.org/repo/uwsampa%2Fgrappa-doxygen/requests
 
 branches:
   only:


### PR DESCRIPTION
In the past our docs available on the web have been generated and uploaded manually. This change 

We chose to put the generated docs and build scripts in a separate repo and GitHub Pages domain name (http://github.com/uwsampa/grpapa-doxygen) to avoid adding automatic commits to the main Grappa website repo. Thus, this change simply tells Travis to start a build on that repo.