### PR TITLE
Fix libunwind symbols missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,12 @@ list(APPEND GRAPPA_ENV
   GLOG_v=1
 )
 
+# libunwind must go after GLOG library in the linking list to resolve its references.
+# We force find_library to use static library because we are putting all dynamics before statics
+find_library(UNWIND_FOUND NAMES libunwind.a REQUIRED)
+message("UNWIND_FOUND: ${UNWIND_FOUND}")
+list(APPEND GRAPPA_STATIC_LIBS ${UNWIND_FOUND})
+
 ######################################################################
 # Google flags
 # in theory, it may come from third-party or from system directories,


### PR DESCRIPTION
GLOG depends on libunwind. Sometimes libunwind symbols were missing.

Without the fix

```
[ 95%] Linking CXX executable hello_world.exe
../../third-party/lib/libglog.a(libglog_la-utilities.o): In function `google::GetStackTrace(void**, int, int)':
utilities.cc:(.text+0x7a6): undefined reference to `_Ux86_64_getcontext'
utilities.cc:(.text+0x7bf): undefined reference to `_ULx86_64_init_local'
utilities.cc:(.text+0x818): undefined reference to `_ULx86_64_get_reg'
utilities.cc:(.text+0x877): undefined reference to `_ULx86_64_step'
collect2: error: ld returned 1 exit status
make[3]: *** [applications/demos/hello_world.exe] Error 1
make[2]: *** [applications/demos/CMakeFiles/demo-hello_world.dir/all] Error 2
make[1]: *** [applications/demos/CMakeFiles/demo-hello_world.dir/rule] Error 2
make: *** [demo-hello_world] Error 2
```

Proposed fix (c9bc0dd) adds the linking flag explicitly.